### PR TITLE
Backtrace support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ pest_derive = "2.1.0"
 structopt = "0.3.3"
 anyhow = "1.0.14"
 rstack = {git = "https://github.com/sfackler/rstack", default-features = false, features = ["dw"]}
+rustc-demangle = "0.1.16"
+cpp_demangle = "0.2.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ pest = "2.1.2"
 pest_derive = "2.1.0"
 structopt = "0.3.3"
 anyhow = "1.0.14"
+rstack = {git = "https://github.com/sfackler/rstack", default-features = false, features = ["dw"]}

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Backtrace {
+        pub(crate) threads: Vec<ThreadBacktrace>,
+    }
+    impl Backtrace {
+        pub fn threads(&self) -> &[ThreadBacktrace] {
+            &self.threads
+        }
+    }
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ThreadBacktrace {
+        pub(crate) name: Option<String>,
+        pub(crate) id: u32,
+        pub(crate) frames: Vec<Frame>,
+    }
+
+    impl ThreadBacktrace {
+        pub fn name(&self) -> Option<&str> {
+            self.name.as_ref().map(String::as_ref)
+        }
+        pub fn frames(&self) -> &[Frame] {
+            &self.frames
+        }
+        pub fn id(&self) -> u32 {
+            self.id
+        }
+    }
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Frame {
+        pub(crate) ip: usize,
+        pub(crate) sym: Option<Symbol>,
+    }
+    impl Frame {
+        pub fn ip(&self) -> usize {
+            self.ip
+        }
+
+        pub fn sym(&self) -> Option<&Symbol> {
+            self.sym.as_ref()
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Symbol {
+        pub(crate) name: String,
+        pub(crate) offset: usize,
+        pub(crate) addr: usize,
+        pub(crate) size: usize,
+    }
+
+    impl Symbol {
+        pub fn name(&self) -> &str {
+            self.name.as_ref()
+        }
+
+        pub fn offset(&self) -> usize {
+            self.offset
+        }
+
+        pub fn addr(&self) -> usize {
+            self.addr
+        }
+
+        pub fn size(&self) -> usize {
+            self.size
+        }
+    }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn print_syscall_event(
                         for (i,frame) in thread.frames().iter().enumerate() {
                             write!(wr, "\t {}: ", i)?;
                             if let Some(sym) = frame.sym() {
-                               writeln!(wr, "{}", sym.name())?;
+                               writeln!(wr, "`{}`", sym.demangle())?;
                             } else {
                                 writeln!(wr, "0x{:016x}", frame.ip())?;
                             }

--- a/src/syscall_decode.rs
+++ b/src/syscall_decode.rs
@@ -215,6 +215,7 @@ impl<'a> Decoder<'a> {
             name: syscall_spec.name.clone(),
             args,
             ret: Some(ret),
+            backtrace: None
         })
     }
 }


### PR DESCRIPTION
Features:
- backtraces can be captured, via `libunwind`
- C++ symbols are demangled correctly
- Rust symbols are not demangled: space for further improvements.